### PR TITLE
Update base docker image to pickup the new version of GO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM corelight/ubuntu-go-npm:v0.6
+FROM corelight/ubuntu-go-npm:v0.7
 LABEL maintainer="Corelight AWS Team <aws@corelight.com>"
 LABEL description="Ubuntu-based builder including Go, NPM and Ruby tool FPM"
 


### PR DESCRIPTION
Updating the base image reference to pull in newer version of GO